### PR TITLE
Support multiple frame rates per mode line

### DIFF
--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -2,16 +2,20 @@ const CONNECTED_REGEX = /^(\S+) connected (?:(\d+)x(\d+))?/;
 const POSITION_REGEX = /\s+(\d+)x([0-9i]+)\+(\d+)\+(\d+)\s+/;
 const DISCONNECTED_REGEX = /^(\S+) disconnected/;
 const MODE_REGEX = /^\s+(\d+)x([0-9i]+)\s+((?:\d+\.)?\d+)([*+ ]?)([+* ]?)/;
+const MODE_CURRENT_FRAME_RATE_REGEX = /^([^*]+)/;
 const ROTATION_LEFT = /^([^(]+) left \((?:(\d+)x(\d+))?/;
 const ROTATION_RIGHT = /^([^(]+) right \((?:(\d+)x(\d+))?/;
 const ROTATION_INVERTED = /^([^(]+) inverted \((?:(\d+)x(\d+))?/;
 
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX = /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX =
+  /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX_CUSTOM = /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX_CUSTOM =
+  /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 const VERBOSE_HOR_MODE_REGEX = /^\s*h:\s+width\s+([0-9]+).+/;
-const VERBOSE_VERT_MODE_REGEX = /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
+const VERBOSE_VERT_MODE_REGEX =
+  /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
 const VERBOSE_ANY_LINE_REGEX = /^\s+[^\n]*/;
 const VERBOSE_EDID_START_LINE = /^\s+EDID:/;
 const VERBOSE_EDID_NEXT_LINE = /^\s+([0-f]{32})/;
@@ -20,14 +24,15 @@ const VERBOSE_ROTATION_RIGHT = /^[^(]+\([^(]+\) right \(/;
 const VERBOSE_ROTATION_INVERTED = /^[^(]+\([^(]+\) inverted \(/;
 const VERBOSE_BRIGHTNESS = /^\s+Brightness: ([0-9.]+)/;
 
-
 function xrandrParser(input, options = {}) {
   let strInput = input;
-  const parseOptions = {verbosedInput: false, debug: false, ...options};
+  const parseOptions = { verbosedInput: false, debug: false, ...options };
   if (Buffer.isBuffer(input)) {
     strInput = input.toString();
   }
-  const lines = strInput.split('\n');
+
+  const lines = strInput.split("\n");
+
   const result = {};
   let mode = {};
   let lastInterface;
@@ -37,13 +42,15 @@ function xrandrParser(input, options = {}) {
     let parts;
     if (CONNECTED_REGEX.test(line)) {
       if (parseOptions.debug) {
-        console.log('CONNECTED_REGEX', line);
+        console.log("CONNECTED_REGEX", line);
       }
+
       parts = CONNECTED_REGEX.exec(line);
+
       result[parts[1]] = {
         connected: true,
         modes: [],
-        rotation: 'normal'
+        rotation: "normal",
       };
       if (parts[2] && parts[3]) {
         result[parts[1]].width = parseInt(parts[2], 10);
@@ -51,19 +58,19 @@ function xrandrParser(input, options = {}) {
       }
       if (!parseOptions.verbosedInput) {
         if (ROTATION_LEFT.test(line)) {
-          result[parts[1]].rotation = 'left';
+          result[parts[1]].rotation = "left";
         } else if (ROTATION_RIGHT.test(line)) {
-          result[parts[1]].rotation = 'right';
+          result[parts[1]].rotation = "right";
         } else if (ROTATION_INVERTED.test(line)) {
-          result[parts[1]].rotation = 'inverted';
+          result[parts[1]].rotation = "inverted";
         }
       } else {
         if (VERBOSE_ROTATION_LEFT.test(line)) {
-          result[parts[1]].rotation = 'left';
+          result[parts[1]].rotation = "left";
         } else if (VERBOSE_ROTATION_RIGHT.test(line)) {
-          result[parts[1]].rotation = 'right';
+          result[parts[1]].rotation = "right";
         } else if (VERBOSE_ROTATION_INVERTED.test(line)) {
-          result[parts[1]].rotation = 'inverted';
+          result[parts[1]].rotation = "inverted";
         }
       }
 
@@ -71,62 +78,105 @@ function xrandrParser(input, options = {}) {
       if (position) {
         result[parts[1]].position = {
           x: parseInt(position[3], 10),
-          y: parseInt(position[4], 10)
+          y: parseInt(position[4], 10),
         };
       }
 
       lastInterface = parts[1];
     } else if (DISCONNECTED_REGEX.test(line)) {
       if (parseOptions.debug) {
-        console.log('DISCONNECTED_REGEX', line);
+        console.log("DISCONNECTED_REGEX", line);
       }
       parts = DISCONNECTED_REGEX.exec(line);
       result[parts[1]] = {
         connected: false,
-        modes: []
+        modes: [],
       };
       lastInterface = parts[1];
-    } else if (!parseOptions.verbosedInput && lastInterface && MODE_REGEX.test(line)) {
+    } else if (
+      !parseOptions.verbosedInput &&
+      lastInterface &&
+      MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('MODE_REGEX', line);
+        console.log("MODE_REGEX", line);
       }
+
       parts = MODE_REGEX.exec(line);
+
+      let frameRates;
+      let frameRate;
+
+      // Regex pattern to match string until asterisk
+      frameRates = MODE_CURRENT_FRAME_RATE_REGEX.exec(line);
+      // Consider the element in the 0th position and splitting it based
+      // on the empty space and then removing the empty space using filter method
+      frameRates = frameRates[1].split(" ").filter((e) => e);
+      // Check if the asterisk exists in the line(string)
+      let checkAsteriskPresence = line.includes("*");
+
+      if (checkAsteriskPresence) {
+        // If asterisk exists taking the last frame rate from the array
+        frameRate = frameRates.slice(-1)[0];
+      } else {
+        // If asterisk does not exist, considering the default first frame rate from the array
+        frameRate = frameRates[1];
+      }
+
       mode = {
         width: parseInt(parts[1], 10),
         height: parseInt(parts[2], 10),
-        rate: parseFloat(parts[3])
+        rate: parseFloat(frameRate),
       };
+
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
-      if (parts[4] === '+' || parts[5] === '+') mode.native = true;
-      if (parts[4] === '*' || parts[5] === '*') mode.current = true;
+      if (parts[4] === "+" || parts[5] === "+") mode.native = true;
+      // If asterisk exists then adding the current key to the mode
+      if (checkAsteriskPresence) mode.current = true;
       result[lastInterface].modes.push(mode);
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_BRIGHTNESS.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_BRIGHTNESS.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_BRIGHTNESS', line);
+        console.log("VERBOSE_BRIGHTNESS", line);
       }
       parts = VERBOSE_BRIGHTNESS.exec(line);
       result[lastInterface].brightness = parseFloat(parts[1]);
-    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_HOR_MODE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      mode &&
+      VERBOSE_HOR_MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_HOR_MODE_REGEX', line);
+        console.log("VERBOSE_HOR_MODE_REGEX", line);
       }
       parts = VERBOSE_HOR_MODE_REGEX.exec(line);
       mode.width = parseInt(parts[1], 10);
-    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_VERT_MODE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      mode &&
+      VERBOSE_VERT_MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_VERT_MODE_REGEX', line);
+        console.log("VERBOSE_VERT_MODE_REGEX", line);
       }
       parts = VERBOSE_VERT_MODE_REGEX.exec(line);
       mode.height = parseInt(parts[1], 10);
       mode.rate = parseFloat(parts[2]);
       result[lastInterface].modes.push(mode);
       mode = null;
-    } else if (parseOptions.verbosedInput
-      && lastInterface
-      && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line))
-      && (!VERBOSE_EDID_START_LINE.test(line))) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) &&
+      !VERBOSE_EDID_START_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM', line);
+        console.log("VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM", line);
       }
       parts = VERBOSE_MODE_REGEX.exec(line);
       if (!parts) {
@@ -138,23 +188,36 @@ function xrandrParser(input, options = {}) {
         height: parseInt(parts[2], 10)
       }; */
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
-      if (line.includes('+preferred')) mode.native = true;
-      if (line.includes('*current')) mode.current = true;
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_START_LINE.test(line)) {
+      if (line.includes("+preferred")) mode.native = true;
+      if (line.includes("*current")) mode.current = true;
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_EDID_START_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_EDID_START_LINE', line);
+        console.log("VERBOSE_EDID_START_LINE", line);
       }
       startParseEdid = true;
-      result[lastInterface].edid = '';
-    } else if (startParseEdid && parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_NEXT_LINE.test(line)) {
+      result[lastInterface].edid = "";
+    } else if (
+      startParseEdid &&
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_EDID_NEXT_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_EDID_NEXT_LINE', line);
+        console.log("VERBOSE_EDID_NEXT_LINE", line);
       }
       parts = VERBOSE_EDID_NEXT_LINE.exec(line);
       result[lastInterface].edid += parts[1];
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_ANY_LINE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_ANY_LINE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
-        console.log('VERBOSE_ANY_LINE_REGEX', line);
+        console.log("VERBOSE_ANY_LINE_REGEX", line);
       }
       if (startParseEdid) {
         startParseEdid = false;
@@ -166,7 +229,4 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-export {
-  xrandrParser as parser,
-  xrandrParser as default
-};
+export { xrandrParser as parser, xrandrParser as default };

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -31,7 +31,7 @@ function xrandrParser(input, options = {}) {
     strInput = input.toString();
   }
 
-  const lines = strInput.split("\n");
+  const lines = strInput.split('\n');
 
   const result = {};
   let mode = {};
@@ -42,7 +42,7 @@ function xrandrParser(input, options = {}) {
     let parts;
     if (CONNECTED_REGEX.test(line)) {
       if (parseOptions.debug) {
-        console.log("CONNECTED_REGEX", line);
+        console.log('CONNECTED_REGEX', line);
       }
 
       parts = CONNECTED_REGEX.exec(line);
@@ -50,7 +50,7 @@ function xrandrParser(input, options = {}) {
       result[parts[1]] = {
         connected: true,
         modes: [],
-        rotation: "normal",
+        rotation: 'normal',
       };
       if (parts[2] && parts[3]) {
         result[parts[1]].width = parseInt(parts[2], 10);
@@ -58,19 +58,19 @@ function xrandrParser(input, options = {}) {
       }
       if (!parseOptions.verbosedInput) {
         if (ROTATION_LEFT.test(line)) {
-          result[parts[1]].rotation = "left";
+          result[parts[1]].rotation = 'left';
         } else if (ROTATION_RIGHT.test(line)) {
-          result[parts[1]].rotation = "right";
+          result[parts[1]].rotation = 'right';
         } else if (ROTATION_INVERTED.test(line)) {
-          result[parts[1]].rotation = "inverted";
+          result[parts[1]].rotation = 'inverted';
         }
       } else {
         if (VERBOSE_ROTATION_LEFT.test(line)) {
-          result[parts[1]].rotation = "left";
+          result[parts[1]].rotation = 'left';
         } else if (VERBOSE_ROTATION_RIGHT.test(line)) {
-          result[parts[1]].rotation = "right";
+          result[parts[1]].rotation = 'right';
         } else if (VERBOSE_ROTATION_INVERTED.test(line)) {
-          result[parts[1]].rotation = "inverted";
+          result[parts[1]].rotation = 'inverted';
         }
       }
 
@@ -85,7 +85,7 @@ function xrandrParser(input, options = {}) {
       lastInterface = parts[1];
     } else if (DISCONNECTED_REGEX.test(line)) {
       if (parseOptions.debug) {
-        console.log("DISCONNECTED_REGEX", line);
+        console.log('DISCONNECTED_REGEX', line);
       }
       parts = DISCONNECTED_REGEX.exec(line);
       result[parts[1]] = {
@@ -99,7 +99,7 @@ function xrandrParser(input, options = {}) {
       MODE_REGEX.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("MODE_REGEX", line);
+        console.log('MODE_REGEX', line);
       }
 
       parts = MODE_REGEX.exec(line);
@@ -111,9 +111,9 @@ function xrandrParser(input, options = {}) {
       frameRates = MODE_CURRENT_FRAME_RATE_REGEX.exec(line);
       // Consider the element in the 0th position and splitting it based
       // on the empty space and then removing the empty space using filter method
-      frameRates = frameRates[1].split(" ").filter((e) => e);
+      frameRates = frameRates[1].split(' ').filter((e) => e);
       // Check if the asterisk exists in the line(string)
-      let checkAsteriskPresence = line.includes("*");
+      let checkAsteriskPresence = line.includes('*');
 
       if (checkAsteriskPresence) {
         // If asterisk exists taking the last frame rate from the array
@@ -130,7 +130,7 @@ function xrandrParser(input, options = {}) {
       };
 
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
-      if (parts[4] === "+" || parts[5] === "+") mode.native = true;
+      if (parts[4] === '+' || parts[5] === '+') mode.native = true;
       // If asterisk exists then adding the current key to the mode
       if (checkAsteriskPresence) mode.current = true;
       result[lastInterface].modes.push(mode);
@@ -140,7 +140,7 @@ function xrandrParser(input, options = {}) {
       VERBOSE_BRIGHTNESS.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_BRIGHTNESS", line);
+        console.log('VERBOSE_BRIGHTNESS', line);
       }
       parts = VERBOSE_BRIGHTNESS.exec(line);
       result[lastInterface].brightness = parseFloat(parts[1]);
@@ -151,7 +151,7 @@ function xrandrParser(input, options = {}) {
       VERBOSE_HOR_MODE_REGEX.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_HOR_MODE_REGEX", line);
+        console.log('VERBOSE_HOR_MODE_REGEX', line);
       }
       parts = VERBOSE_HOR_MODE_REGEX.exec(line);
       mode.width = parseInt(parts[1], 10);
@@ -162,7 +162,7 @@ function xrandrParser(input, options = {}) {
       VERBOSE_VERT_MODE_REGEX.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_VERT_MODE_REGEX", line);
+        console.log('VERBOSE_VERT_MODE_REGEX', line);
       }
       parts = VERBOSE_VERT_MODE_REGEX.exec(line);
       mode.height = parseInt(parts[1], 10);
@@ -176,7 +176,7 @@ function xrandrParser(input, options = {}) {
       !VERBOSE_EDID_START_LINE.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM", line);
+        console.log('VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM', line);
       }
       parts = VERBOSE_MODE_REGEX.exec(line);
       if (!parts) {
@@ -188,18 +188,18 @@ function xrandrParser(input, options = {}) {
         height: parseInt(parts[2], 10)
       }; */
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
-      if (line.includes("+preferred")) mode.native = true;
-      if (line.includes("*current")) mode.current = true;
+      if (line.includes('+preferred')) mode.native = true;
+      if (line.includes('*current')) mode.current = true;
     } else if (
       parseOptions.verbosedInput &&
       lastInterface &&
       VERBOSE_EDID_START_LINE.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_EDID_START_LINE", line);
+        console.log('VERBOSE_EDID_START_LINE', line);
       }
       startParseEdid = true;
-      result[lastInterface].edid = "";
+      result[lastInterface].edid = '';
     } else if (
       startParseEdid &&
       parseOptions.verbosedInput &&
@@ -207,7 +207,7 @@ function xrandrParser(input, options = {}) {
       VERBOSE_EDID_NEXT_LINE.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_EDID_NEXT_LINE", line);
+        console.log('VERBOSE_EDID_NEXT_LINE', line);
       }
       parts = VERBOSE_EDID_NEXT_LINE.exec(line);
       result[lastInterface].edid += parts[1];
@@ -217,7 +217,7 @@ function xrandrParser(input, options = {}) {
       VERBOSE_ANY_LINE_REGEX.test(line)
     ) {
       if (parseOptions.debug) {
-        console.log("VERBOSE_ANY_LINE_REGEX", line);
+        console.log('VERBOSE_ANY_LINE_REGEX', line);
       }
       if (startParseEdid) {
         startParseEdid = false;


### PR DESCRIPTION
- Current implementation is considering only the first column of frame rates with asterisk as a current frame rate while creating a mode. This means that the parser fails to deduct the current mode if the system isn't using the frame rates in the first column.

For example,
```

Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
DP1 disconnected (normal left inverted right x axis y axis)
HDMI1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 531mm x 299mm
   1920x1080     60.00*+  50.00    59.94
   1920x1080i    60.00    50.00    59.94
   1680x1050     59.88
   1440x900      59.90
   1280x960      60.00
   1366x768      59.79    60.00
   1360x768      60.02
   1280x800      59.91
   1280x768      59.87
   1280x720      60.00    50.00    59.94
   1024x768      60.00
   800x600       60.32    56.25
   720x576       50.00
   720x576i      50.00
   720x480       60.00    59.94
   640x480       60.00    59.94
HDMI2 disconnected (normal left inverted right x axis y axis)
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

- If we have asterisk in other columns of frame rates. It is not taking that frame rate into consideration as a current frame rate.

For example
```
Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
DP1 disconnected (normal left inverted right x axis y axis)
HDMI1 connected primary 1920x1080+0+0 (normal left inverted right x axis y axis) 531mm x 299mm
   1920x1080     60.00+  50.00    59.94
   1920x1080i    60.00    50.00    59.94
   1680x1050     59.88
   1440x900      59.90
   1280x960      60.00
   1366x768      59.79    60.00
   1360x768      60.02
   1280x800      59.91
   1280x768      59.87
   1280x720      60.00    50.00*    59.94
   1024x768      60.00
   800x600       60.32    56.25
   720x576       50.00
   720x576i      50.00
   720x480       60.00    59.94
   640x480       60.00    59.94
HDMI2 disconnected (normal left inverted right x axis y axis)
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

-  So I implemented the functionality to consider the current frame rate as a frame rate with asterisk among the other frame rates regardless of columns and adding a key value pair `current : true` to the mode object.
