### PR TITLE
unrecoginsable modelines

### DIFF
--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -8,14 +8,11 @@ const ROTATION_RIGHT = /^([^(]+) right \((?:(\d+)x(\d+))?/;
 const ROTATION_INVERTED = /^([^(]+) inverted \((?:(\d+)x(\d+))?/;
 
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX =
-  /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX = /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX_CUSTOM =
-  /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX_CUSTOM = /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 const VERBOSE_HOR_MODE_REGEX = /^\s*h:\s+width\s+([0-9]+).+/;
-const VERBOSE_VERT_MODE_REGEX =
-  /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
+const VERBOSE_VERT_MODE_REGEX = /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
 const VERBOSE_ANY_LINE_REGEX = /^\s+[^\n]*/;
 const VERBOSE_EDID_START_LINE = /^\s+EDID:/;
 const VERBOSE_EDID_NEXT_LINE = /^\s+([0-f]{32})/;
@@ -26,7 +23,7 @@ const VERBOSE_BRIGHTNESS = /^\s+Brightness: ([0-9.]+)/;
 
 function xrandrParser(input, options = {}) {
   let strInput = input;
-  const parseOptions = { verbosedInput: false, debug: false, ...options };
+  const parseOptions = {verbosedInput: false, debug: false, ...options};
   if (Buffer.isBuffer(input)) {
     strInput = input.toString();
   }
@@ -46,7 +43,7 @@ function xrandrParser(input, options = {}) {
       result[parts[1]] = {
         connected: true,
         modes: [],
-        rotation: 'normal',
+        rotation: 'normal'
       };
       if (parts[2] && parts[3]) {
         result[parts[1]].width = parseInt(parts[2], 10);
@@ -74,7 +71,7 @@ function xrandrParser(input, options = {}) {
       if (position) {
         result[parts[1]].position = {
           x: parseInt(position[3], 10),
-          y: parseInt(position[4], 10),
+          y: parseInt(position[4], 10)
         };
       }
 
@@ -86,14 +83,10 @@ function xrandrParser(input, options = {}) {
       parts = DISCONNECTED_REGEX.exec(line);
       result[parts[1]] = {
         connected: false,
-        modes: [],
+        modes: []
       };
       lastInterface = parts[1];
-    } else if (
-      !parseOptions.verbosedInput &&
-      lastInterface &&
-      MODE_REGEX.test(line)
-    ) {
+    } else if (!parseOptions.verbosedInput && lastInterface && MODE_REGEX.test(line)) {
       if (parseOptions.debug) {
         console.log('MODE_REGEX', line);
       }
@@ -110,46 +103,30 @@ function xrandrParser(input, options = {}) {
 
       // If asterisk exists taking the last frame rate from the array
       // If asterisk does not exist, considering the default first frame rate from the array
-      const frameRate = checkAsteriskPresence
-        ? frameRates.slice(-1)[0]
-        : frameRates[1];
+      const frameRate = checkAsteriskPresence ? frameRates.slice(-1)[0] : frameRates[1];
 
       mode = {
         width: parseInt(parts[1], 10),
         height: parseInt(parts[2], 10),
-        rate: parseFloat(frameRate),
+        rate: parseFloat(frameRate)
       };
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
       if (parts[4] === '+' || parts[5] === '+') mode.native = true;
       if (checkAsteriskPresence) mode.current = true;
       result[lastInterface].modes.push(mode);
-    } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      VERBOSE_BRIGHTNESS.test(line)
-    ) {
+    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_BRIGHTNESS.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_BRIGHTNESS', line);
       }
       parts = VERBOSE_BRIGHTNESS.exec(line);
       result[lastInterface].brightness = parseFloat(parts[1]);
-    } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      mode &&
-      VERBOSE_HOR_MODE_REGEX.test(line)
-    ) {
+    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_HOR_MODE_REGEX.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_HOR_MODE_REGEX', line);
       }
       parts = VERBOSE_HOR_MODE_REGEX.exec(line);
       mode.width = parseInt(parts[1], 10);
-    } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      mode &&
-      VERBOSE_VERT_MODE_REGEX.test(line)
-    ) {
+    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_VERT_MODE_REGEX.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_VERT_MODE_REGEX', line);
       }
@@ -159,11 +136,10 @@ function xrandrParser(input, options = {}) {
       result[lastInterface].modes.push(mode);
       mode = null;
     } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) &&
-      !VERBOSE_EDID_START_LINE.test(line)
-    ) {
+      parseOptions.verbosedInput 
+      && lastInterface 
+      && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) 
+      && (!VERBOSE_EDID_START_LINE.test(line))) {
       if (parseOptions.debug) {
         console.log('VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM', line);
       }
@@ -179,32 +155,19 @@ function xrandrParser(input, options = {}) {
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
       if (line.includes('+preferred')) mode.native = true;
       if (line.includes('*current')) mode.current = true;
-    } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      VERBOSE_EDID_START_LINE.test(line)
-    ) {
+    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_START_LINE.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_EDID_START_LINE', line);
       }
       startParseEdid = true;
       result[lastInterface].edid = '';
-    } else if (
-      startParseEdid &&
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      VERBOSE_EDID_NEXT_LINE.test(line)
-    ) {
+    } else if (startParseEdid && parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_NEXT_LINE.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_EDID_NEXT_LINE', line);
       }
       parts = VERBOSE_EDID_NEXT_LINE.exec(line);
       result[lastInterface].edid += parts[1];
-    } else if (
-      parseOptions.verbosedInput &&
-      lastInterface &&
-      VERBOSE_ANY_LINE_REGEX.test(line)
-    ) {
+    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_ANY_LINE_REGEX.test(line)) {
       if (parseOptions.debug) {
         console.log('VERBOSE_ANY_LINE_REGEX', line);
       }
@@ -218,4 +181,7 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-export { xrandrParser as parser, xrandrParser as default };
+export { 
+  xrandrParser as parser,
+  xrandrParser as default 
+};

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -1,8 +1,7 @@
 const CONNECTED_REGEX = /^(\S+) connected (?:(\d+)x(\d+))?/;
 const POSITION_REGEX = /\s+(\d+)x([0-9i]+)\+(\d+)\+(\d+)\s+/;
 const DISCONNECTED_REGEX = /^(\S+) disconnected/;
-const MODE_REGEX =
-  /^\s+(\d+)x([0-9i_((?:\d+\.)?\d+)]+)\s+((?:\d+\.)?\d+)([*+ ]?)([+* ]?)/;
+const MODE_REGEX = /^\s+(\d+)x([0-9i_.]+)\s+((?:\d+\.)?\d+)([*+ ]?)([+* ]?)/;
 const MODE_CURRENT_FRAME_RATE_REGEX = /^([^*]+)/;
 const ROTATION_LEFT = /^([^(]+) left \((?:(\d+)x(\d+))?/;
 const ROTATION_RIGHT = /^([^(]+) right \((?:(\d+)x(\d+))?/;

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -8,11 +8,14 @@ const ROTATION_RIGHT = /^([^(]+) right \((?:(\d+)x(\d+))?/;
 const ROTATION_INVERTED = /^([^(]+) inverted \((?:(\d+)x(\d+))?/;
 
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX = /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX =
+  /^\s*(\d+)x([0-9i]+)(?:_.+)?\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 // eslint-disable-next-line max-len
-const VERBOSE_MODE_REGEX_CUSTOM = /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
+const VERBOSE_MODE_REGEX_CUSTOM =
+  /^\s*([^\s]+)\s+(?:\(0x[0-9a-f]+\)\.)?\s*([0-9.]+MHz)?\s*((\+|-)HSync)?\s*((\+|-)VSync)?\s*(\*current)?\s*(\+preferred)?/;
 const VERBOSE_HOR_MODE_REGEX = /^\s*h:\s+width\s+([0-9]+).+/;
-const VERBOSE_VERT_MODE_REGEX = /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
+const VERBOSE_VERT_MODE_REGEX =
+  /^\s*v:\s+height\s+([0-9]+).+clock\s+([0-9.]+)Hz/;
 const VERBOSE_ANY_LINE_REGEX = /^\s+[^\n]*/;
 const VERBOSE_EDID_START_LINE = /^\s+EDID:/;
 const VERBOSE_EDID_NEXT_LINE = /^\s+([0-f]{32})/;
@@ -21,10 +24,9 @@ const VERBOSE_ROTATION_RIGHT = /^[^(]+\([^(]+\) right \(/;
 const VERBOSE_ROTATION_INVERTED = /^[^(]+\([^(]+\) inverted \(/;
 const VERBOSE_BRIGHTNESS = /^\s+Brightness: ([0-9.]+)/;
 
-
 function xrandrParser(input, options = {}) {
   let strInput = input;
-  const parseOptions = {verbosedInput: false, debug: false, ...options};
+  const parseOptions = { verbosedInput: false, debug: false, ...options };
   if (Buffer.isBuffer(input)) {
     strInput = input.toString();
   }
@@ -44,7 +46,7 @@ function xrandrParser(input, options = {}) {
       result[parts[1]] = {
         connected: true,
         modes: [],
-        rotation: 'normal'
+        rotation: 'normal',
       };
       if (parts[2] && parts[3]) {
         result[parts[1]].width = parseInt(parts[2], 10);
@@ -72,7 +74,7 @@ function xrandrParser(input, options = {}) {
       if (position) {
         result[parts[1]].position = {
           x: parseInt(position[3], 10),
-          y: parseInt(position[4], 10)
+          y: parseInt(position[4], 10),
         };
       }
 
@@ -84,14 +86,20 @@ function xrandrParser(input, options = {}) {
       parts = DISCONNECTED_REGEX.exec(line);
       result[parts[1]] = {
         connected: false,
-        modes: []
+        modes: [],
       };
       lastInterface = parts[1];
-    } else if (!parseOptions.verbosedInput && lastInterface && MODE_REGEX.test(line)) {
+    } else if (
+      !parseOptions.verbosedInput &&
+      lastInterface &&
+      MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('MODE_REGEX', line);
       }
       parts = MODE_REGEX.exec(line);
+
+      console.log(parts);
 
       let frameRates;
       // Regex pattern to match string until asterisk
@@ -104,30 +112,46 @@ function xrandrParser(input, options = {}) {
 
       // If asterisk exists taking the last frame rate from the array
       // If asterisk does not exist, considering the default first frame rate from the array
-      const frameRate = checkAsteriskPresence ? frameRates.slice(-1)[0] : frameRates[1];
+      const frameRate = checkAsteriskPresence
+        ? frameRates.slice(-1)[0]
+        : frameRates[1];
 
       mode = {
         width: parseInt(parts[1], 10),
         height: parseInt(parts[2], 10),
-        rate: parseFloat(frameRate)
+        rate: parseFloat(frameRate),
       };
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
       if (parts[4] === '+' || parts[5] === '+') mode.native = true;
       if (checkAsteriskPresence) mode.current = true;
       result[lastInterface].modes.push(mode);
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_BRIGHTNESS.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_BRIGHTNESS.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_BRIGHTNESS', line);
       }
       parts = VERBOSE_BRIGHTNESS.exec(line);
       result[lastInterface].brightness = parseFloat(parts[1]);
-    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_HOR_MODE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      mode &&
+      VERBOSE_HOR_MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_HOR_MODE_REGEX', line);
       }
       parts = VERBOSE_HOR_MODE_REGEX.exec(line);
       mode.width = parseInt(parts[1], 10);
-    } else if (parseOptions.verbosedInput && lastInterface && mode && VERBOSE_VERT_MODE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      mode &&
+      VERBOSE_VERT_MODE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_VERT_MODE_REGEX', line);
       }
@@ -136,10 +160,12 @@ function xrandrParser(input, options = {}) {
       mode.rate = parseFloat(parts[2]);
       result[lastInterface].modes.push(mode);
       mode = null;
-    } else if (parseOptions.verbosedInput
-      && lastInterface
-      && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line))
-      && (!VERBOSE_EDID_START_LINE.test(line))) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) &&
+      !VERBOSE_EDID_START_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM', line);
       }
@@ -155,19 +181,32 @@ function xrandrParser(input, options = {}) {
       if (/^[0-9]+i$/.test(parts[2])) mode.interlaced = true;
       if (line.includes('+preferred')) mode.native = true;
       if (line.includes('*current')) mode.current = true;
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_START_LINE.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_EDID_START_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_EDID_START_LINE', line);
       }
       startParseEdid = true;
       result[lastInterface].edid = '';
-    } else if (startParseEdid && parseOptions.verbosedInput && lastInterface && VERBOSE_EDID_NEXT_LINE.test(line)) {
+    } else if (
+      startParseEdid &&
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_EDID_NEXT_LINE.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_EDID_NEXT_LINE', line);
       }
       parts = VERBOSE_EDID_NEXT_LINE.exec(line);
       result[lastInterface].edid += parts[1];
-    } else if (parseOptions.verbosedInput && lastInterface && VERBOSE_ANY_LINE_REGEX.test(line)) {
+    } else if (
+      parseOptions.verbosedInput &&
+      lastInterface &&
+      VERBOSE_ANY_LINE_REGEX.test(line)
+    ) {
       if (parseOptions.debug) {
         console.log('VERBOSE_ANY_LINE_REGEX', line);
       }
@@ -181,7 +220,4 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-export {
-  xrandrParser as parser,
-  xrandrParser as default
-};
+export { xrandrParser as parser, xrandrParser as default };

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -20,7 +20,6 @@ const VERBOSE_ROTATION_LEFT = /^[^(]+\([^(]+\) left \(/;
 const VERBOSE_ROTATION_RIGHT = /^[^(]+\([^(]+\) right \(/;
 const VERBOSE_ROTATION_INVERTED = /^[^(]+\([^(]+\) inverted \(/;
 const VERBOSE_BRIGHTNESS = /^\s+Brightness: ([0-9.]+)/;
-
 function xrandrParser(input, options = {}) {
   let strInput = input;
   const parseOptions = {verbosedInput: false, debug: false, ...options};
@@ -135,8 +134,7 @@ function xrandrParser(input, options = {}) {
       mode.rate = parseFloat(parts[2]);
       result[lastInterface].modes.push(mode);
       mode = null;
-    } else if (
-      parseOptions.verbosedInput 
+    } else if (parseOptions.verbosedInput 
       && lastInterface 
       && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) 
       && (!VERBOSE_EDID_START_LINE.test(line))) {
@@ -181,7 +179,7 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-export { 
+export {
   xrandrParser as parser,
-  xrandrParser as default 
+  xrandrParser as default
 };

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -1,7 +1,8 @@
 const CONNECTED_REGEX = /^(\S+) connected (?:(\d+)x(\d+))?/;
 const POSITION_REGEX = /\s+(\d+)x([0-9i]+)\+(\d+)\+(\d+)\s+/;
 const DISCONNECTED_REGEX = /^(\S+) disconnected/;
-const MODE_REGEX = /^\s+(\d+)x([0-9i]+)\s+((?:\d+\.)?\d+)([*+ ]?)([+* ]?)/;
+const MODE_REGEX =
+  /^\s+(\d+)x([0-9i_((?:\d+\.)?\d+)]+)\s+((?:\d+\.)?\d+)([*+ ]?)([+* ]?)/;
 const MODE_CURRENT_FRAME_RATE_REGEX = /^([^*]+)/;
 const ROTATION_LEFT = /^([^(]+) left \((?:(\d+)x(\d+))?/;
 const ROTATION_RIGHT = /^([^(]+) right \((?:(\d+)x(\d+))?/;
@@ -98,8 +99,6 @@ function xrandrParser(input, options = {}) {
         console.log('MODE_REGEX', line);
       }
       parts = MODE_REGEX.exec(line);
-
-      console.log(parts);
 
       let frameRates;
       // Regex pattern to match string until asterisk
@@ -220,4 +219,6 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-export { xrandrParser as parser, xrandrParser as default };
+//export { xrandrParser as parser, xrandrParser as default };
+
+module.exports = xrandrParser;

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -20,6 +20,8 @@ const VERBOSE_ROTATION_LEFT = /^[^(]+\([^(]+\) left \(/;
 const VERBOSE_ROTATION_RIGHT = /^[^(]+\([^(]+\) right \(/;
 const VERBOSE_ROTATION_INVERTED = /^[^(]+\([^(]+\) inverted \(/;
 const VERBOSE_BRIGHTNESS = /^\s+Brightness: ([0-9.]+)/;
+
+
 function xrandrParser(input, options = {}) {
   let strInput = input;
   const parseOptions = {verbosedInput: false, debug: false, ...options};
@@ -134,9 +136,9 @@ function xrandrParser(input, options = {}) {
       mode.rate = parseFloat(parts[2]);
       result[lastInterface].modes.push(mode);
       mode = null;
-    } else if (parseOptions.verbosedInput 
-      && lastInterface 
-      && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line)) 
+    } else if (parseOptions.verbosedInput
+      && lastInterface
+      && (VERBOSE_MODE_REGEX.test(line) || VERBOSE_MODE_REGEX_CUSTOM.test(line))
       && (!VERBOSE_EDID_START_LINE.test(line))) {
       if (parseOptions.debug) {
         console.log('VERBOSE_MODE_REGEX || VERBOSE_MODE_REGEX_CUSTOM', line);

--- a/src/xrandr.js
+++ b/src/xrandr.js
@@ -219,6 +219,4 @@ function xrandrParser(input, options = {}) {
   return result;
 }
 
-//export { xrandrParser as parser, xrandrParser as default };
-
-module.exports = xrandrParser;
+export { xrandrParser as parser, xrandrParser as default };


### PR DESCRIPTION
**Bug**

node-xrandr does not recognize modelines if they include `_`. E.g. `1920x1080` is recognised but `1920x1080_60.00` is not recognised, even though it accepted as a modeline in xorg.conf and recognised by `xrandr` as well.

**To fix the above issue**

Modified the regex pattern of `MODE_REGEX`, which now accepts the screen resolution in both format such as `1920x1080_60.00`,`1920x1080`.

i.e. 

**Input**

```
$: xrandr
Screen 0: minimum 8 x 8, current 1920 x 1080, maximum 32767 x 32767
DP1 disconnected (normal left inverted right x axis y axis)
DP2 disconnected (normal left inverted right x axis y axis)
HDMI1 connected 1920x1080+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
   1920x1080_60.00  59.94*+
   2048x1080     60.00 +
   1920x1080     60.00    59.94  
   1280x1024     60.02  
   1024x768      70.07    60.00  
   800x600       72.19    60.32    56.25  
   640x480       72.81    60.00  
HDMI2 disconnected (normal left inverted right x axis y axis)
VIRTUAL1 disconnected (normal left inverted right x axis y axis)
```

**node-xrandr returns an empty modes array based on the input above** 

```
{
 "DP1": {
  "connected": false,
  "modes": []
 },
 "DP2": {
  "connected": false,
  "modes": []
 },
 "HDMI1": {
  "connected": true,
  "modes": [],
  "rotation": "normal",
  "width": 1920,
  "height": 1080,
  "position": {
   "x": 0,
   "y": 0
  }
 },
 "HDMI2": {
  "connected": false,
  "modes": []
 },
 "VIRTUAL1": {
  "connected": false,
  "modes": []
 }
}
```
**Expected output( This PR has a solution for this issue and it produces the below expected output )**

```
{
 "DP1": {
  "connected": false,
  "modes": []
 },
 "DP2": {
  "connected": false,
  "modes": []
 },
 "HDMI1": {
  "connected": true,
  "modes": [
   {
    "width": 1920,
    "height": 1080,
    "rate": 59.94,
    "native": true,
    "current": true
   },
   {
    "width": 2048,
    "height": 1080,
    "rate": 60,
    "native": true
   },
   {
    "width": 1920,
    "height": 1080,
    "rate": 60
   },
   {
    "width": 1280,
    "height": 1024,
    "rate": 60.02
   },
   {
    "width": 1024,
    "height": 768,
    "rate": 70.07
   },
   {
    "width": 800,
    "height": 600,
    "rate": 72.19
   },
   {
    "width": 640,
    "height": 480,
    "rate": 72.81
   }
  ],
  "rotation": "normal",
  "width": 1920,
  "height": 1080,
  "position": {
   "x": 0,
   "y": 0
  }
 },
 "HDMI2": {
  "connected": false,
  "modes": []
 },
 "VIRTUAL1": {
  "connected": false,
  "modes": []
 }
}
```

